### PR TITLE
Sanitize env and add setup docs

### DIFF
--- a/.env
+++ b/.env
@@ -3,14 +3,14 @@
 
 # OpenAI API Key (default provider)
 #OPENAI_API_KEY="1234"
-OPENAI_API_KEY=YOUR_OPENAI_API_KEY_HERE
-OPENAI_BASE_URL=http://10.0.0.81:1234/v1
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_BASE_URL=http://localhost:1234/v1
 
 # Google Gemini API Key (for Gemini provider)
 # GOOGLE_GENERATIVE_AI_API_KEY=your-gemini-api-key-here
 
 # OpenRouter API Key (for OpenRouter provider)
-OPENROUTER_API_KEY=YOUR_OPENROUTER_API_KEY_HERE
+OPENROUTER_API_KEY=your_openrouter_api_key_here
 
 # xAI API Key (for xAI provider)
 # XAI_API_KEY=your-xai-api-key-here-
@@ -19,4 +19,4 @@ OPENROUTER_API_KEY=YOUR_OPENROUTER_API_KEY_HERE
 
 # Optional: Set debug mode
 # DEBUG=true
-OLLAMA_BASE_URL=http://10.0.0.81:1234
+OLLAMA_BASE_URL=http://localhost:1234

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This project is a starting point for building a fitness assistant powered by various Task Master tools.
 
+## Configuration
+
+The repository ships with a `.env` file that contains placeholder values for API keys. Copy this file locally and add your own credentials before running any scripts:
+
+```bash
+cp .env .env.local
+# Edit .env.local and fill in your API keys
+```
+
+Keep your real API keys out of version control.
+
 ## Running Tests
 
 Tests are not yet implemented, but a basic test runner has been added to provide a placeholder entry point. Execute the following command to run the test script:


### PR DESCRIPTION
## Summary
- sanitize API key values in `.env`
- document how to provide API credentials locally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a1040c4c8328af6d239c4baae82e